### PR TITLE
Generator improvements

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -31,7 +31,10 @@ module.exports = class extends Generator {
         s3folder: slugify(this.appname),
         slug: slugify(this.appname),
         appleFallback: `fallbacks/${slugify(this.appname)}-apple.png`,
-        newsletterFallback: `fallbacks/${slugify(this.appname)}-fallback.png`
+        newsletterFallback: `fallbacks/${slugify(this.appname)}-fallback.png`,
+        readMeFallbackSrc: `![alt](/src/fallbacks/${slugify(
+          this.appname
+        )}-fallback.png)`
       };
     });
   }

--- a/generators/app/templates/README.md
+++ b/generators/app/templates/README.md
@@ -2,6 +2,8 @@
 
 <%= meta.description %>
 
+<%= meta.readMeFallbackSrc %>
+
 This project was created with `generator-axios`, Axios' yeoman generator for making static interactive graphics that can be embedded in our news stream. This documentation will help you work with the graphics rig to make awesome internet things.
 
 **Note** — You may also want to look at the documentation for the generator for some additional understanding of what each of the files in this project does and how they all work together.

--- a/generators/app/templates/scripts/fallbacks.js
+++ b/generators/app/templates/scripts/fallbacks.js
@@ -74,9 +74,17 @@ const resizeSocial = async dms => {
 
 const init = async () => {
   fs.emptyDirSync(destinationPath); // remove existing fallbacks
-  const results = await Promise.all(
-    fallbacks.map(size => takeScreenshot(size))
-  );
+
+  try {
+    const results = await Promise.all(
+      fallbacks.map(size => takeScreenshot(size))
+    );
+  } catch {
+    console.error(
+      "Unable to connect at http://0.0.0.0:3000/. 🚨 Make sure you have gulp serve running. 🚨"
+    );
+  }
+
   await resizeSocial(fallbacks.filter(d => d.name === "social")[0]);
   console.log("fallbacks created ✨");
 };


### PR DESCRIPTION
1. Improved error handling when fallbacks script doesn't work due to now having `gulp serve` running.
2. Adds fallback to README on deployment, like this:

![image](https://user-images.githubusercontent.com/16782770/113925592-d2b44580-97b0-11eb-802d-714575354cbd.png)
